### PR TITLE
feat: add laravel passport 6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `laravel-mongodb-passport` will be documented in this file
 
+## 1.1.3 - 2018-04-24
+- fix support for laravel-framework 5.6, laravel-passport 5, laravel-mongodb 3.4
+
 ## 1.1.2 - 2018-03-22
 - fix support for laravel-framework 5.6, laravel-passport 5, laravel-mongodb 3.4
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "illuminate/support": "^5.5",
         "jenssegers/mongodb": "3.3.* || 3.4.*",
-        "laravel/passport": "4.0.* || 5.0.*"
+        "laravel/passport": "4.0.* || 5.0.* || 6.0.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This change adds Laravel passport 6 support

Part of https://github.com/designmynight/laravel-mongodb-passport/issues/6

fyi @willtj 