### PR TITLE
fix: don't cast scopes as an array

### DIFF
--- a/src/Passport/Token.php
+++ b/src/Passport/Token.php
@@ -40,7 +40,6 @@ class Token extends Model
      * @var array
      */
     protected $casts = [
-        'scopes' => 'array',
         'revoked' => 'bool',
     ];
 


### PR DESCRIPTION
Because it's already an array when it comes back from MongoDB - accessing `$token->scopes` without this change throws an error because it's trying to cast from a MySQL json-encoded array
```
json_decode() expects parameter 1 to be string, array given
```