### PR TITLE
Support for new laravel-mongodb version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "illuminate/support": "^5.5",
-        "jenssegers/mongodb": "3.3.* || 3.4.*",
+        "jenssegers/mongodb": "3.3.* || 3.4.* || 3.5.*",
         "laravel/passport": "4.0.* || 5.0.* || 6.0.* || 7.0.* || dev*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "designmynight/laravel-mongodb-passport",
+    "name": "vaishnavmhetre/laravel-mongodb-passport",
     "description": "A package to allow laravel/passport use with jenssegers/laravel-mongodb",
     "homepage": "https://github.com/designmynight/laravel-mongodb-passport",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "vaishnavmhetre/laravel-mongodb-passport",
+    "name": "designmynight/laravel-mongodb-passport",
     "description": "A package to allow laravel/passport use with jenssegers/laravel-mongodb",
     "homepage": "https://github.com/designmynight/laravel-mongodb-passport",
     "license": "MIT",


### PR DESCRIPTION
Allowing version `jenseggers/laravel-mongodb = 3.5.*` to patch critical problem [jenssegers/laravel-mongodb/pull/1712]

It will be a breaking change as it is specific to `laravel = "5.8"` and **will not work for any** `laravel = "<5.8"`
Hence recommended to _release new version_ with this change applied specifically for `laravel = "5.8"`.