### PR TITLE
Add client command

### DIFF
--- a/src/Console/ClientCommand.php
+++ b/src/Console/ClientCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DesignMyNight\Mongodb\Console;
+
+use DesignMyNight\Mongodb\Passport\Client;
+use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Console\ClientCommand as PassportClientCommand;
+
+class ClientCommand extends PassportClientCommand
+{
+    /**
+     * Create a new personal access client.
+     *
+     * @param  \Laravel\Passport\ClientRepository  $clients
+     * @return void
+     */
+    protected function createPersonalClient(ClientRepository $clients)
+    {
+        $name = $this->option('name') ?: $this->ask(
+            'What should we name the personal access client?',
+            config('app.name').' Personal Access Client'
+        );
+
+        $client = $clients->createPersonalAccessClient(
+            null, $name, 'http://localhost'
+        );
+
+        $this->info('Personal access client created successfully.');
+
+        $this->patchedOutputClientDetails($client);
+    }
+
+    /**
+     * Create a new password grant client.
+     *
+     * @param  \Laravel\Passport\ClientRepository  $clients
+     * @return void
+     */
+    protected function createPasswordClient(ClientRepository $clients)
+    {
+        $name = $this->option('name') ?: $this->ask(
+            'What should we name the password grant client?',
+            config('app.name').' Password Grant Client'
+        );
+
+        $client = $clients->createPasswordGrantClient(
+            null, $name, 'http://localhost'
+        );
+
+        $this->info('Password grant client created successfully.');
+
+        $this->patchedOutputClientDetails($client);
+    }
+
+    /**
+     * Create a client credentials grant client.
+     *
+     * @param  \Laravel\Passport\ClientRepository  $clients
+     * @return void
+     */
+    protected function createClientCredentialsClient(ClientRepository $clients)
+    {
+        $name = $this->option('name') ?: $this->ask(
+            'What should we name the client?',
+            config('app.name').' ClientCredentials Grant Client'
+        );
+
+        $client = $clients->create(
+            null, $name, ''
+        );
+
+        $this->info('New client created successfully.');
+
+        $this->patchedOutputClientDetails($client);
+    }
+
+    /**
+     * Create a authorization code client.
+     *
+     * @param  \Laravel\Passport\ClientRepository  $clients
+     * @return void
+     */
+    protected function createAuthCodeClient(ClientRepository $clients)
+    {
+        $userId = $this->option('user_id') ?: $this->ask(
+            'Which user ID should the client be assigned to?'
+        );
+
+        $name = $this->option('name') ?: $this->ask(
+            'What should we name the client?'
+        );
+
+        $redirect = $this->option('redirect_uri') ?: $this->ask(
+            'Where should we redirect the request after authorization?',
+            url('/auth/callback')
+        );
+
+        $client = $clients->create(
+            $userId, $name, $redirect, false, false, ! $this->option('public')
+        );
+
+        $this->info('New client created successfully.');
+
+        $this->patchedOutputClientDetails($client);
+    }
+
+    /**
+     * Output the client's ID and secret key.
+     *
+     * @param  \Laravel\Passport\Client  $client
+     * @return void
+     */
+    protected function patchedOutputClientDetails(Client $client)
+    {
+        $this->line('<comment>Client ID:</comment> '.$client->id);
+        $this->line('<comment>Client secret:</comment> '.$client->secret);
+    }
+}

--- a/src/MongodbPassportServiceProvider.php
+++ b/src/MongodbPassportServiceProvider.php
@@ -2,14 +2,15 @@
 
 namespace DesignMyNight\Mongodb;
 
+use DesignMyNight\Mongodb\Console\ClientCommand;
 use Illuminate\Support\ServiceProvider;
 use DesignMyNight\Mongodb\Passport\AuthCode;
 use DesignMyNight\Mongodb\Passport\Bridge\RefreshTokenRepository;
 use DesignMyNight\Mongodb\Passport\Client;
 use DesignMyNight\Mongodb\Passport\PersonalAccessClient;
-use DesignMyNight\Mongodb\Passport\RefreshToken;
 use DesignMyNight\Mongodb\Passport\Token;
 use Laravel\Passport\Bridge\RefreshTokenRepository as PassportRefreshTokenRepository;
+use Laravel\Passport\Console\ClientCommand as OriginalClientCommand;
 use Laravel\Passport\Passport;
 
 class MongodbPassportServiceProvider extends ServiceProvider
@@ -26,6 +27,10 @@ class MongodbPassportServiceProvider extends ServiceProvider
 
         $this->app->bind(PassportRefreshTokenRepository::class, function () {
             return $this->app->make(RefreshTokenRepository::class);
+        });
+
+        $this->app->extend(OriginalClientCommand::class, function () {
+            return new ClientCommand();
         });
     }
 }


### PR DESCRIPTION
In order to execute the command `php artisan passport:install`, the ClientCommand needs to be overwritten and patched.