### PR TITLE
chore: updated readme file with the new support version of laravel

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ class User extends Authenticatable
  5.5.x    | 4.0.x, 5.0.x, 6.0.x, 7.0.x   | 1.1.x
  5.6.x    | 4.0.x, 5.0.x, 6.0.x, 7.0.x   | 1.1.x
  6.x      | 4.0.x, 5.0.x, 6.0.x, 7.x, 8.x| 1.2.x
+ 8.x      | 10.x                         | 3.x
   
 And add the service provider in `config/app.php`:
 


### PR DESCRIPTION
- added Laravel 8.x and Passport 10.x to Laravel version Compatibility list.